### PR TITLE
Fix: Hide character names on mobile view

### DIFF
--- a/src/components/CharacterSelector.tsx
+++ b/src/components/CharacterSelector.tsx
@@ -239,7 +239,9 @@ export default function CharacterSelector({ onChange }: Props) {
                 alt={`${char.name} 的头像`}
                 className="w-16 h-16 mx-auto mb-2 rounded-full"
               />
-              <div className="text-lg font-semibold">{char.name}</div>
+              <div className="text-lg font-semibold hidden sm:inline">
+                {char.name}
+              </div>
               <div className="text-sm text-gray-500">{char.type}</div>
               {isSelected && (
                 <div className="mt-2 text-green-600 font-bold">✔ 已选择</div>


### PR DESCRIPTION
### Description

This PR addresses Issue #3: the character selection UI on mobile was too long due to displaying full character names. This update uses Tailwind’s responsive utility classes (`hidden sm:inline`) to hide the name text on small viewports, preserving a clean layout.

### Changes
- Hides character names on screens <640px
- Keeps names visible on tablets and desktops
- Ensures no functionality is broken

### Testing
- Confirmed character names disappear on mobile in Chrome DevTools
- Confirmed they remain visible on desktop

### Screenshots

**Mobile View (names hidden):**  
<img src="https://github.com/user-attachments/assets/f5253c2f-115a-45df-884b-7fb064fffbe7" alt="Mobile View" width="450" />


**Desktop View (names visible):**  
<img src="https://github.com/user-attachments/assets/0a66f64f-a81c-4fc1-9743-391767f0e19c" alt="Mobile View" width="600">

Closes #3
